### PR TITLE
Fix dot access

### DIFF
--- a/conf/__init__.py
+++ b/conf/__init__.py
@@ -41,4 +41,4 @@ Generic configuration module.
 | ``conf.load('complete/path/to/conf.yml')``
 """
 
-from conf.reader import load, get
+from conf.reader import *


### PR DESCRIPTION
Fix dot access for loaded properties.

The loaded properties would only be global to conf.reader, instead of global to conf. This means that this example:

```
import conf
your_setting = conf.your_setting
```

did not actually work.

This fixes that by importing all globals from conf.reader.

Alternatively, calling the load() method could be moved to the __init__.py file with some refactoring.